### PR TITLE
Allow guzzlehttp/psr7: ^1.4|^2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=7.3",
-        "guzzlehttp/psr7": "^1.4",
+        "guzzlehttp/psr7": "^1.4|^2.4",
         "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {

--- a/src/Handler/CurlRequestHandler.php
+++ b/src/Handler/CurlRequestHandler.php
@@ -192,7 +192,7 @@ class CurlRequestHandler implements RequestHandler
     protected function parseResponse($message)
     {
         try {
-            return \GuzzleHttp\Psr7\parse_response($message);
+            return \GuzzleHttp\Psr7\Message::parseResponse($message);
         } catch (\InvalidArgumentException $e) {
             throw ParseResponseException::create($e);
         }


### PR DESCRIPTION
Remove call to deprecated method. Add support for psr7 > 2.4